### PR TITLE
Changed task.execute to task.invoke 

### DIFF
--- a/lib/guard/rake.rb
+++ b/lib/guard/rake.rb
@@ -37,7 +37,17 @@ module Guard
 
     def run_rake_task
       UI.info "running #{@task}"
-      ::Rake::Task[@task].execute
+      task = ::Rake::Task[@task]
+      reenable_task_and_prerequisites task
+      task.invoke
     end
+    
+  private
+    
+    def reenable_task_and_prerequisites(task)
+      task.reenable
+      task.prerequisites.each { |pre| reenable_task_and_prerequisites(::Rake::Task[pre]) }
+    end
+    
   end
 end


### PR DESCRIPTION
Execute doesn't fire off the dependencies, but invoke means a task won't fire more than once. To make it work in the context of guard, we have to reenable the task we want to run and all it's dependencies, every time.

There is probably a better way to do this.
